### PR TITLE
Django 1.11 fixes

### DIFF
--- a/omero_weberror/urls.py
+++ b/omero_weberror/urls.py
@@ -23,12 +23,11 @@
 # Version: 1.0
 #
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^error_404/$', views.error404, name="weberror404"),
     url(r'^error_500/$', views.error500, name="weberror500"),
     url(r'^warning/$', views.warning, name="weberrorwarn"),
-)
+]


### PR DESCRIPTION
Fixes app to work on Django 1.11

To test:
 - Go to ```/weberror/error_404/``` and click on the links to get various errors.